### PR TITLE
Call onChangeCallback for all adds and removes

### DIFF
--- a/src/app/angular2-multiselect-dropdown/multiselect.component.ts
+++ b/src/app/angular2-multiselect-dropdown/multiselect.component.ts
@@ -75,7 +75,6 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor {
         if(this.isSelectAll){
             this.isSelectAll = false;
         }
-        this.onChangeCallback(this.selectedItems);
     }
     private onTouchedCallback: () => void = noop;
     private onChangeCallback: (_: any) => void = noop;
@@ -132,6 +131,7 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor {
         }
         else
             this.selectedItems.push(item);
+        this.onChangeCallback(this.selectedItems);
     }
     removeSelected(clickedItem: ListItem){
         this.selectedItems.forEach(item => {
@@ -139,6 +139,7 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor {
                this.selectedItems.splice(this.selectedItems.indexOf(item),1);
            }
         });    
+        this.onChangeCallback(this.selectedItems);
     }
     toggleDropdown(){
         this.isActive = !this.isActive;


### PR DESCRIPTION
Moving the onChangeCallback to actual add and removal of items means it gets updated when clicking the 'X' on the selected items when the dropdown isn't open. This PR currently works for individual item selection in the dropdown, select and deselect all, and by doing item removals from the collapsed dropdown.