### PR TITLE
initialized selectedItems

### DIFF
--- a/src/app/angular2-multiselect-dropdown/multiselect.component.ts
+++ b/src/app/angular2-multiselect-dropdown/multiselect.component.ts
@@ -42,7 +42,7 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor {
     @Output('onDeSelectAll')
     onDeSelectAll: EventEmitter<Array<ListItem>> = new EventEmitter<Array<ListItem>>();
 
-    public selectedItems: Array<ListItem>;
+    public selectedItems: Array<ListItem>=[];
     public isActive: boolean = false;
     public isSelectAll: boolean = false;
     filter: ListItem = new ListItem();


### PR DESCRIPTION
I was getting null reference error while using this component without ngModel binding.
sample code snippet:
<angular2-multiselect [data]="basicExampleList" [settings]="dropdownSettings3" (onSelect)="onItemSelect($event)" (onDeSelect)="OnItemDeSelect($event)" (onSelectAll)="onSelectAll($event)" (onDeSelectAll)="onDeSelectAll($event)"></angular2-multiselect>

By initializing selectedItems, got rid of error.