### PR TITLE
Added a setting to hide the badges and always show the text

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Angular 2 multiselect dropdown component for web applications. Easy to integrate
 
 ## Getting Started
 ### Installation
-- The Mutiselect Dropdown package is published on the [npm](https://www.npmjs.com/package/angular2-multiselect-dropdown) Registry. 
+- The Mutiselect Dropdown package is published on the [npm](https://www.npmjs.com/package/angular2-multiselect-dropdown) Registry.
 - Install the package :
     `npm install angular2-multiselect-dropdown`
 
@@ -58,8 +58,8 @@ export class AppComponent implements OnInit {
                                 {"id":4,"itemName":"Canada"},
                                 {"id":5,"itemName":"South Korea"}
                             ];
-        this.dropdownSettings = { 
-                                  singleSelection: false, 
+        this.dropdownSettings = {
+                                  singleSelection: false,
                                   text:"Select Countries",
                                   selectAllText:'Select All',
                                   unSelectAllText:'UnSelect All',
@@ -84,11 +84,11 @@ export class AppComponent implements OnInit {
 }
 ```
 
-Add the following component tag in you template 
+Add the following component tag in you template
 ```html
-<angular2-multiselect [data]="dropdownList" [(ngModel)]="selectedItems" 
-    [settings]="dropdownSettings" 
-    (onSelect)="onItemSelect($event)" 
+<angular2-multiselect [data]="dropdownList" [(ngModel)]="selectedItems"
+    [settings]="dropdownSettings"
+    (onSelect)="onItemSelect($event)"
     (onDeSelect)="OnItemDeSelect($event)"
     (onSelectAll)="onSelectAll($event)"
     (onDeSelectAll)="onDeSelectAll($event)"></angular2-multiselect>
@@ -108,6 +108,7 @@ The following list of settings are supported by the component. Configure the set
 | enableSearchFilter | Boolean | Enable filter option for the list. | false |
 | maxHeight | Number | Set maximum height of the dropdown list in px. | 300 |
 | badgeShowLimit | Number | Limit the number of badges/items to show in the input field. If not set will show all selected. | All |
+| hideBadges | Boolean | Hide the badges and always show the text | false |
 | classes | String | Custom classes to the dropdown component. Classes are added to the dropdown selector tag. To add multiple classes, the value should be space separated class names.| '' |
 | limitSelection | Number | Limit the selection of number of items from the dropdown list. Once the limit is reached, all unselected items gets disabled. | none |
 | disabled | Boolean | Disable the dropdown | false |
@@ -122,7 +123,7 @@ The following list of settings are supported by the component. Configure the set
     Example : (onSelectAll)="onSelectAll($event)"
 - `onDeSelectAll` - Returns an empty array.
     Example : (onDeSelectAll)="onDeSelectAll($event)"
-    
+
 
 ## Run locally
 - Clone the repository or downlod the .zip,.tar files.

--- a/src/app/angular2-multiselect-dropdown/multiselect.component.html
+++ b/src/app/angular2-multiselect-dropdown/multiselect.component.html
@@ -1,21 +1,21 @@
 <div class="cuppa-dropdown" (clickOutside)="closeDropdown()">
     <div class="selected-list">
         <button class="c-btn" (click)="toggleDropdown($event)" [disabled]="settings.disabled" [ngClass]="{'disabled': settings.disabled}">
-            <span *ngIf="selectedItems?.length == 0">{{settings.text}}</span>
+            <span *ngIf="selectedItems?.length == 0 || settings.hideBadges">{{settings.text}}</span>
             <span *ngIf="settings.singleSelection">
                 <span *ngFor="let item of selectedItems;trackBy: trackByFn;">
                     {{item.itemName}}
                 </span>
             </span>
-            <div class="c-list" *ngIf="selectedItems?.length > 0 && !settings.singleSelection">
+            <div class="c-list" *ngIf="selectedItems?.length > 0 && !settings.singleSelection && !settings.hideBadges">
                 <div class="c-token" *ngFor="let item of selectedItems;trackBy: trackByFn;let k = index" [hidden]="k > settings.badgeShowLimit-1">
                     <span class="c-label">{{item.itemName}}</span>
                     <span class="fa fa-remove" (click)="onItemClick(item)" disabled="true"></span>
                 </div>
-            </div> 
-            <span *ngIf="selectedItems?.length > settings.badgeShowLimit">+{{selectedItems?.length - settings.badgeShowLimit }}</span>
+            </div>
+            <span *ngIf="selectedItems?.length > settings.badgeShowLimit && !settings.hideBadges">+{{selectedItems?.length - settings.badgeShowLimit }}</span>
             <span class="fa" [ngClass]="{'fa-angle-down': !isActive,'fa-angle-up':isActive}"></span>
-        </button>      
+        </button>
     </div>
     <div class="dropdown-list" [hidden]="!isActive">
     <div class="arrow-up"></div>
@@ -26,11 +26,11 @@
                 <span [hidden]="isSelectAll">{{settings.selectAllText}}</span>
                 <span [hidden]="!isSelectAll">{{settings.unSelectAllText}}</span>
             </label>
-        </div>   
+        </div>
         <div class="list-filter" *ngIf="settings.enableSearchFilter">
             <span class="fa fa-search"></span>
             <input type="text" [placeholder]="settings.searchPlaceholderText" [(ngModel)]="filter.itemName">
-        </div> 
+        </div>
     <ul [style.maxHeight] = "settings.maxHeight+'px'">
         <li *ngFor="let item of data | listFilter:filter; let i = index;" (click)="onItemClick(item,i)" class="pure-checkbox">
             <input type="checkbox" [checked]="isSelected(item)" [disabled]="settings.limitSelection == selectedItems?.length && !isSelected(item)"/>

--- a/src/app/angular2-multiselect-dropdown/multiselect.component.ts
+++ b/src/app/angular2-multiselect-dropdown/multiselect.component.ts
@@ -24,12 +24,12 @@ const noop = () => {
 
 export class AngularMultiSelect implements OnInit, ControlValueAccessor {
 
-    @Input() 
+    @Input()
     data: Array<ListItem>;
-    
+
     @Input()
     settings:DropdownSettings;
-    
+
     @Output('onSelect')
     onSelect: EventEmitter<ListItem> = new EventEmitter<ListItem>();
 
@@ -55,6 +55,7 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor {
         enableSearchFilter: false,
         maxHeight: 300,
         badgeShowLimit: 999999999999,
+        hideBadges: false,
         classes:'',
         disabled: false,
         searchPlaceholderText: 'Search'
@@ -76,7 +77,7 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor {
                 if(this.settings.disabled){
                     return false;
                 }
-        
+
                 let found = this.isSelected(item);
                 let limit = this.selectedItems.length < this.settings.limitSelection ? true : false;
 
@@ -85,13 +86,13 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor {
                         if(limit){
                             this.addSelected(item);
                             this.onSelect.emit(item);
-                        } 
+                        }
                     }
                     else{
                         this.addSelected(item);
                         this.onSelect.emit(item);
                     }
-                    
+
                 }
                 else{
                 this.removeSelected(item);
@@ -102,7 +103,7 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor {
                 }
                 if(this.data.length == this.selectedItems.length){
                     this.isSelectAll = true;
-                }    
+                }
     }
     private onTouchedCallback: () => void = noop;
     private onChangeCallback: (_: any) => void = noop;
@@ -111,7 +112,7 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor {
         if (value !== undefined && value !== null) {
             if(this.settings.singleSelection){
                 try{
-                    
+
                     if(value.length > 1){
                         this.selectedItems = [value[0]];
                         throw new MyException(404, { "msg": "Single Selection Mode, Selected Items cannot have more than one item." });
@@ -123,7 +124,7 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor {
                 catch(e){
                     console.error(e.body.msg);
                 }
-                
+
             }
             else{
                 if(this.settings.limitSelection){
@@ -176,7 +177,7 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor {
            if(clickedItem.id === item.id){
                this.selectedItems.splice(this.selectedItems.indexOf(item),1);
            }
-        });    
+        });
         this.onChangeCallback(this.selectedItems);
     }
     toggleDropdown(evt){
@@ -199,7 +200,7 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor {
             this.isSelectAll = false;
             this.onChangeCallback(this.selectedItems);
             this.onDeSelectAll.emit(this.selectedItems);
-        }     
+        }
     }
 }
 

--- a/src/app/angular2-multiselect-dropdown/multiselect.interface.ts
+++ b/src/app/angular2-multiselect-dropdown/multiselect.interface.ts
@@ -7,8 +7,9 @@ export interface DropdownSettings{
     enableSearchFilter: Boolean;
     maxHeight: Number;
     badgeShowLimit: Number;
+    hideBadges: Boolean;
     classes: String;
     limitSelection?: Number;
     disabled?: Boolean;
     searchPlaceholderText: String;
-} 
+}


### PR DESCRIPTION
This option can be useful, when the information about the selected items is shown on another place and the multiselect is only used for the selection. In this case the badges only show redundant information. 

For example if the multiselect is used to show/hide columns of a table. 