### PR TITLE
Trigger data grouping after onInit

### DIFF
--- a/src/app/angular2-multiselect-dropdown/multiselect.component.ts
+++ b/src/app/angular2-multiselect-dropdown/multiselect.component.ts
@@ -189,6 +189,9 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor {
         if (this.settings.disabled) {
             return false;
         }
+        if (this.settings.groupBy) {
+            this.groupedData = this.transformData(this.data, this.settings.groupBy);
+        }
         this.isActive = !this.isActive;
         evt.preventDefault();
     }


### PR DESCRIPTION
Currently, `groupBy` is only checked in `ngOnInit`. Hence if new options are subsequently added, they will not be grouped and will not even show up in the dropdown. One possible solution is to check grouping again when the dropdown is toggled to prevent excessive computation.