### PR TITLE
Fixed duplicate items returned when lazy loading is used.

### DIFF
--- a/src/app/angular2-multiselect-dropdown/multiselect.component.ts
+++ b/src/app/angular2-multiselect-dropdown/multiselect.component.ts
@@ -123,7 +123,7 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor, OnChang
                 }
             }
         }
-        if (changes.settings && !changes.settings.firstChange) { 
+        if (changes.settings && !changes.settings.firstChange) {
             this.settings = Object.assign(this.defaultSettings, this.settings);
         }
     }
@@ -332,7 +332,7 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor, OnChang
         var firstTemp = ""+first;
         first = parseInt(firstTemp) < 0 ? 0 : parseInt(firstTemp);
             this.renderChunk(first, this.cachedItemsLen);
-            this.lastRepaintY = scrollPos;      
+            this.lastRepaintY = scrollPos;
     }
     public filterInfiniteList(evt: any){
         var filteredElems:Array<any> = [];
@@ -342,6 +342,7 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor, OnChang
               for(var prop in el){
                   if(el[prop].toString().toLowerCase().indexOf(evt.target.value.toString().toLowerCase()) >=0 ){
                       filteredElems.push(el);
+                      break;
                   }
               }
           });
@@ -358,7 +359,7 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor, OnChang
             this.totalHeight = this.itemHeight * this.data.length;
             this.totalRows = this.data.length;
             this.updateView(this.scrollTop);
-        } 
+        }
     }
 }
 


### PR DESCRIPTION
Fixes issue #177 

When the item list data contains multiple keys that can match the search string then multiple entries are added to the result.
For example, given the itemlist below and searching for `eur` will give back two identical entries for Europe.
```
	itemList: any[] = [
		{ id: 0, itemName: 'Europe', symbol: 'euro' },
		{ id: 1, itemName: 'Asia', symbol: 'asia' },
	];
```