### PR TITLE
Fix slice/splice typo in selectedItems binding

### DIFF
--- a/src/app/angular2-multiselect-dropdown/multiselect.component.ts
+++ b/src/app/angular2-multiselect-dropdown/multiselect.component.ts
@@ -218,7 +218,7 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor, OnChang
             }
             else {
                 if (this.settings.limitSelection) {
-                    this.selectedItems = value.splice(0, this.settings.limitSelection);
+                    this.selectedItems = value.slice(0, this.settings.limitSelection);
                 }
                 else {
                     this.selectedItems = value;


### PR DESCRIPTION
splice caused the bound array to be emptied and selectedItems to not function properly - slice performs the action needed to limit the selectedItem array to the limitSelection option