### PR TITLE
Fix for Angular 10 search and select issues

### DIFF
--- a/projects/angular2-multiselect-dropdown-lib/src/lib/multiselect.component.ts
+++ b/projects/angular2-multiselect-dropdown-lib/src/lib/multiselect.component.ts
@@ -9,7 +9,7 @@ import { Item, Badge, Search, TemplateRenderer, CIcon } from './menu-item';
 import { DataService } from './multiselect.service';
 import { Subscription, Subject } from 'rxjs';
 import { VirtualScrollerModule, VirtualScrollerComponent } from './virtual-scroll/virtual-scroll';
-import { map, debounceTime, distinctUntilChanged, switchMap, tap } from 'rxjs/operators';
+import { map, debounceTime, distinctUntilChanged, switchMap, tap, delay } from 'rxjs/operators';
 import { ThrowStmt } from '@angular/compiler';
 
 export const DROPDOWN_CONTROL_VALUE_ACCESSOR: any = {
@@ -185,7 +185,9 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor, OnChang
                 this.selectedListHeight.val = this.selectedListElem.nativeElement.clientHeight;
             });
         }
-        this.subscription = this.ds.getData().subscribe(data => {
+        this.subscription = this.ds.getData()
+          .pipe(delay(0))
+          .subscribe(data => {
             if (data) {
                 let len = 0;
                 data.forEach((obj: any, i: any) => {
@@ -524,7 +526,7 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor, OnChang
                                         });
                                     }
                                     this.updateGroupInfo(item);
-                
+
                                 }); */
 
                 this.ds.getFilteredData().forEach((el: any) => {
@@ -627,7 +629,6 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor, OnChang
         else if (cnt > 0 && this.filterLength != cnt) {
             this.isFilterSelectAll = false;
         }
-        this.cdr.detectChanges();
     }
     cloneArray(arr: any) {
         let i, copy;
@@ -819,10 +820,10 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor, OnChang
             item.list.forEach((obj: any) => {
                 this.removeSelected(obj);
             });
-            
+
             this.onGroupDeSelect.emit(item);
             this.updateGroupInfo(item);
-            
+
         }
         else {
             item.selected = true;
@@ -834,7 +835,7 @@ export class AngularMultiSelect implements OnInit, ControlValueAccessor, OnChang
             });
             this.onGroupSelect.emit(item);
             this.updateGroupInfo(item);
-            
+
         }
 
 


### PR DESCRIPTION
For some reason `ChangeDetectorRef` in Angular 10 caused search being delayed by one character. Removed it and replaced it with rxjs `delay(0)` to fix `Expression has changed after it was checked` and view not refreshing properly.

Fixes https://github.com/CuppaLabs/angular2-multiselect-dropdown/issues/524 and https://github.com/CuppaLabs/angular2-multiselect-dropdown/issues/527