### PR TITLE
change click event to pointer down to avoid unwanted multiselect closing

### DIFF
--- a/projects/angular2-multiselect-dropdown-lib/src/lib/clickOutside.ts
+++ b/projects/angular2-multiselect-dropdown-lib/src/lib/clickOutside.ts
@@ -10,7 +10,7 @@ export class ClickOutsideDirective {
     @Output()
     public clickOutside = new EventEmitter<MouseEvent>();
 
-    @HostListener('document:click', ['$event', '$event.target'])
+    @HostListener('document:pointerdown', ['$event', '$event.target'])
     @HostListener('document:touchstart', ['$event', '$event.target'])
     public onClick(event: MouseEvent, targetElement: HTMLElement): void {
         if (!targetElement) {


### PR DESCRIPTION
### Expected behavior:
Firefox has the right behavior:

1. User opens the Multiselect
2. Enters some string into the search filter field.
3. User wants to copy the input string by marking it with the mouse pointer.
4. User goes from right to the left while holding the left mouse button to mark the text.
5. User accidentally leaves the Multiselect area and releases left mouse button.
6. Multiselect is still opened after release of the left mouse button and the text of the search filter is marked and ready for copy&paste.

### Wrong behavior
Chrome has the wrong behavior:

1. User opens the Multiselect
2. Enters some string into the search filter field.
3. User wants to copy the input string by marking it with the mouse pointer.
4. User goes from right to the left while holding the left mouse button to mark the text.
5. User accidentally leaves the Multiselect area and releases left mouse button.
6. Multiselect is closed because Chrome triggers the click event based on where the mouseUp event happens.

### Fix
change click event to pointer down to avoid unwanted multiselect closing