### PR TITLE
Add optional chaining to component settings

### DIFF
--- a/projects/angular2-multiselect-dropdown-lib/src/lib/multiselect.component.html
+++ b/projects/angular2-multiselect-dropdown-lib/src/lib/multiselect.component.html
@@ -5,12 +5,12 @@
             <span *ngIf="selectedItems?.length == 0">{{settings.text}}</span>
             <span *ngIf="settings.singleSelection && !badgeTempl">
                 <span *ngFor="let item of selectedItems;trackBy: trackByFn.bind(this);let k = index">
-                    {{item[settings.labelKey]}}
+                    {{item[settings?.labelKey]}}
                 </span>
             </span>
             <span class="c-list" *ngIf="selectedItems?.length > 0 && settings.singleSelection && badgeTempl ">
                 <div class="c-token" *ngFor="let item of selectedItems;trackBy: trackByFn.bind(this);let k = index">
-                    <span *ngIf="!badgeTempl" class="c-label">{{item[settings.labelKey]}}</span>
+                    <span *ngIf="!badgeTempl" class="c-label">{{item[settings?.labelKey]}}</span>
 
                     <span *ngIf="badgeTempl" class="c-label">
                         <c-templateRenderer [data]="badgeTempl" [item]="item"></c-templateRenderer>
@@ -21,8 +21,8 @@
                 </div>
             </span>
             <div class="c-list" *ngIf="selectedItems?.length > 0 && !settings.singleSelection">
-                <div class="c-token" *ngFor="let item of selectedItems;trackBy: trackByFn.bind(this);let k = index" [hidden]="k > settings.badgeShowLimit-1">
-                    <span *ngIf="!badgeTempl" class="c-label">{{item[settings.labelKey]}}</span>
+                <div class="c-token" *ngFor="let item of selectedItems;trackBy: trackByFn.bind(this);let k = index" [hidden]="k > settings?.badgeShowLimit-1">
+                    <span *ngIf="!badgeTempl" class="c-label">{{item[settings?.labelKey]}}</span>
                     <span *ngIf="badgeTempl" class="c-label">
                         <c-templateRenderer [data]="badgeTempl" [item]="item"></c-templateRenderer>
                     </span>
@@ -31,7 +31,7 @@
                     </span>
                 </div>
             </div>
-            <span class="countplaceholder" *ngIf="selectedItems?.length > settings.badgeShowLimit">+{{selectedItems?.length - settings.badgeShowLimit }}</span>
+            <span class="countplaceholder" *ngIf="selectedItems?.length > settings?.badgeShowLimit">+{{selectedItems?.length - settings?.badgeShowLimit }}</span>
             <span class="c-remove clear-all" *ngIf="settings.clearAll && selectedItems?.length > 0 && !settings.disabled" (click)="clearSelection($event);$event.stopPropagation()">
                 <c-icon [name]="'remove'"></c-icon>
             </span>
@@ -126,7 +126,7 @@
                         class="pure-checkbox" [ngClass]="{'selected-item': isSelected(item) == true }">
                         <input *ngIf="settings.showCheckbox" type="checkbox" [checked]="isSelected(item)" [disabled]="(settings.limitSelection == selectedItems?.length && !isSelected(item)) || item.disabled"
                         aria-labelledby="option"/>
-                        <label>{{item[settings.labelKey]}}</label>
+                        <label>{{item[settings?.labelKey]}}</label>
                     </li>
                 </ul>
             </div>
@@ -139,7 +139,7 @@
                         [ngClass]="{'selected-item': isSelected(item) == true }">
                         <input *ngIf="settings.showCheckbox" type="checkbox" [checked]="isSelected(item)" [disabled]="(settings.limitSelection == selectedItems?.length && !isSelected(item)) || item.disabled"
                         />
-                        <label>{{item[settings.labelKey]}}</label>
+                        <label>{{item[settings?.labelKey]}}</label>
                     </li>
                 </ul>
             </div>
@@ -202,7 +202,7 @@
                             class="pure-checkbox">
                             <input *ngIf="settings.showCheckbox && !settings.singleSelection" type="checkbox" [checked]="item.selected" [disabled]="(settings.limitSelection == selectedItems?.length && !isSelected(item)) || item.disabled"
                             />
-                            <label>{{item[settings.labelKey]}}</label>
+                            <label>{{item[settings?.labelKey]}}</label>
                             <ul class="lazyContainer">
                                 <span *ngFor="let val of item.list ; let j = index;">
                                     <li (click)="onItemClick(val,j,$event); $event.stopPropagation()" [ngClass]="{'grp-title': val.grpTitle,'grp-item': !val.grpTitle && !settings.singleSelection}"
@@ -231,13 +231,13 @@
                                 <input *ngIf="settings.showCheckbox && !item.grpTitle && !settings.singleSelection" type="checkbox" [checked]="isSelected(item)"
                                     [disabled]="(settings.limitSelection == selectedItems?.length && !isSelected(item)) || item.disabled"
                                 />
-                                <label>{{item[settings.labelKey]}}</label>
+                                <label>{{item[settings?.labelKey]}}</label>
                             </li>
                             <li (click)="onItemClick(item,i,$event)" *ngIf="!item.grpTitle" [ngClass]="{'grp-title': item.grpTitle,'grp-item': !item.grpTitle && !settings.singleSelection, 'selected-item': isSelected(item) == true }"
                                 class="pure-checkbox">
                                 <input *ngIf="settings.showCheckbox && !item.grpTitle" type="checkbox" [checked]="isSelected(item)" [disabled]="(settings.limitSelection == selectedItems?.length && !isSelected(item)) || item.disabled"
                                 />
-                                <label>{{item[settings.labelKey]}}</label>
+                                <label>{{item[settings?.labelKey]}}</label>
                             </li>
                         </span>
                     </ul>
@@ -252,14 +252,14 @@
                             class="pure-checkbox">
                             <input *ngIf="settings.showCheckbox && !settings.singleSelection" type="checkbox" [checked]="item.selected" [disabled]="(settings.limitSelection == selectedItems?.length && !isSelected(item)) || item.disabled"
                             />
-                            <label>{{item[settings.labelKey]}}</label>
+                            <label>{{item[settings?.labelKey]}}</label>
                             <ul class="lazyContainer">
                                 <span *ngFor="let val of item.list ; let j = index;">
                                     <li (click)="onItemClick(val,j,$event); $event.stopPropagation()" [ngClass]="{'selected-item': isSelected(val) == true,'grp-title': val.grpTitle,'grp-item': !val.grpTitle && !settings.singleSelection}"
                                         class="pure-checkbox">
                                         <input *ngIf="settings.showCheckbox" type="checkbox" [checked]="isSelected(val)" [disabled]="(settings.limitSelection == selectedItems?.length && !isSelected(val)) || val.disabled"
                                         />
-                                        <label>{{val[settings.labelKey]}}</label>
+                                        <label>{{val[settings?.labelKey]}}</label>
                                     </li>
                                 </span>
                             </ul>
@@ -269,17 +269,17 @@
                     <li (click)="onItemClick(item,i,$event)" *ngIf="!item.grpTitle" [ngClass]="{'grp-title': item.grpTitle,'grp-item': !item.grpTitle}" class="pure-checkbox">
                     <input *ngIf="settings.showCheckbox && !item.grpTitle" type="checkbox" [checked]="isSelected(item)" [disabled]="settings.limitSelection == selectedItems?.length && !isSelected(item)"
                     />
-                    <label>{{item[settings.labelKey]}}</label>
+                    <label>{{item[settings?.labelKey]}}</label>
                 </li>
                 <li *ngIf="item.grpTitle && !settings.selectGroup" [ngClass]="{'grp-title': item.grpTitle,'grp-item': !item.grpTitle}" class="pure-checkbox">
                     <input *ngIf="settings.showCheckbox && settings.selectGroup" type="checkbox" [checked]="isSelected(item)" [disabled]="settings.limitSelection == selectedItems?.length && !isSelected(item)"
                     />
-                    <label>{{item[settings.labelKey]}}</label>
+                    <label>{{item[settings?.labelKey]}}</label>
                 </li>
                  <li  (click)="selectGroup(item)" *ngIf="item.grpTitle && settings.selectGroup" [ngClass]="{'grp-title': item.grpTitle,'grp-item': !item.grpTitle}" class="pure-checkbox">
                     <input *ngIf="settings.showCheckbox && settings.selectGroup" type="checkbox" [checked]="item.selected" [disabled]="settings.limitSelection == selectedItems?.length && !isSelected(item)"
                     />
-                    <label>{{item[settings.labelKey]}}</label>
+                    <label>{{item[settings?.labelKey]}}</label>
                 </li>
                 </span> -->
                 </ul>


### PR DESCRIPTION
For strict compiling options of typescript optional chaining has been added to certain settings properties where when compiling the proyect occurs errors like seen in https://github.com/CuppaLabs/angular2-multiselect-dropdown/issues/577